### PR TITLE
Add ability to resolve a value

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -37,6 +37,6 @@ await pWaitFor(() => pathExists('unicorn.png'));
 console.log('Yay! The file now exists.');
 ```
 */
-export default function pWaitFor(condition: () => PromiseLike<boolean> | boolean, options?: Options): Promise<void>;
+export default function pWaitFor<T = void>(condition: (resolve: (value: T) => true) => PromiseLike<boolean> | boolean, options?: Options): Promise<T>;
 
 export {TimeoutError} from 'p-timeout';

--- a/index.js
+++ b/index.js
@@ -12,14 +12,21 @@ export default async function pWaitFor(condition, options = {}) {
 	const promise = new Promise((resolve, reject) => {
 		const check = async () => {
 			try {
-				const value = await condition();
+				let resolvedValue;
+				const resolveValue = value => {
+					resolvedValue = value;
+					// Allows for `return resolve('foo')`
+					return true;
+				};
 
-				if (typeof value !== 'boolean') {
+				const conditionValue = await condition(resolveValue);
+
+				if (typeof conditionValue !== 'boolean') {
 					throw new TypeError('Expected condition to return a boolean');
 				}
 
-				if (value === true) {
-					resolve();
+				if (conditionValue === true) {
+					resolve(resolvedValue);
 				} else {
 					retryTimeout = setTimeout(check, interval);
 				}

--- a/index.js
+++ b/index.js
@@ -10,15 +10,16 @@ export default async function pWaitFor(condition, options = {}) {
 	let retryTimeout;
 
 	const promise = new Promise((resolve, reject) => {
+		let resolvedValue;
+		const resolveValue = value => {
+			resolvedValue = value;
+			// Allows for `return resolve('foo')`
+			return true;
+		};
+
 		const check = async () => {
 			try {
-				let resolvedValue;
-				const resolveValue = value => {
-					resolvedValue = value;
-					// Allows for `return resolve('foo')`
-					return true;
-				};
-
+				resolvedValue = undefined;
 				const conditionValue = await condition(resolveValue);
 
 				if (typeof conditionValue !== 'boolean') {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -6,3 +6,8 @@ expectType<Promise<void>>(pWaitFor(async () => false));
 expectType<Promise<void>>(pWaitFor(() => true, {interval: 1}));
 expectType<Promise<void>>(pWaitFor(() => true, {timeout: 1}));
 expectType<Promise<void>>(pWaitFor(() => true, {before: false}));
+
+expectType<Promise<void>>(pWaitFor(resolve => resolve()));
+expectType<Promise<void>>(pWaitFor(async resolve => resolve()));
+expectType<Promise<string>>(pWaitFor<string>(resolve => resolve('foo')));
+expectType<Promise<string>>(pWaitFor<string>(async resolve => resolve('foo')));

--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ Using the `resolve` callback:
 ```js
 import {globby} from 'globby';
 
-const jsFiles = await pWaitFor(async (resolve) => {
+const jsFiles = await pWaitFor(async resolve => {
   const paths = await globby(['*.js']);
   if (paths.length > 0) {
     return resolve(paths);
@@ -39,7 +39,7 @@ Use with TypeScript:
 ```ts
 import {globby} from 'globby';
 
-const tsFiles = await pWaitFor<string[]>(async (resolve) => {
+const tsFiles = await pWaitFor<string[]>(async resolve => {
   const paths = await globby(['*.ts']);
   if (paths.length > 0) {
     return resolve(paths);

--- a/readme.md
+++ b/readme.md
@@ -27,9 +27,7 @@ import {globby} from 'globby';
 
 const jsFiles = await pWaitFor(async resolve => {
   const paths = await globby(['*.js']);
-  if (paths.length > 0) {
-    return resolve(paths);
-  }
+  return paths.length > 0 ? resolve(paths) : false;
 });
 console.log(jsFiles);
 ```
@@ -41,9 +39,7 @@ import {globby} from 'globby';
 
 const tsFiles = await pWaitFor<string[]>(async resolve => {
   const paths = await globby(['*.ts']);
-  if (paths.length > 0) {
-    return resolve(paths);
-  }
+  return paths.length > 0 ? resolve(paths) : false;
 });
 // `tsFiles` is typed as a `string[]`
 console.log(tsFiles);

--- a/readme.md
+++ b/readme.md
@@ -20,17 +20,52 @@ await pWaitFor(() => pathExists('unicorn.png'));
 console.log('Yay! The file now exists.');
 ```
 
+Using the `resolve` callback:
+
+```js
+import {globby} from 'globby';
+
+const jsFiles = await pWaitFor(async (resolve) => {
+  const paths = await globby(['*.js']);
+  if (paths.length > 0) {
+    return resolve(paths);
+  }
+});
+console.log(jsFiles);
+```
+
+Use with TypeScript:
+
+```ts
+import {globby} from 'globby';
+
+const tsFiles = await pWaitFor<string[]>(async (resolve) => {
+  const paths = await globby(['*.ts']);
+  if (paths.length > 0) {
+    return resolve(paths);
+  }
+});
+// `tsFiles` is typed as a `string[]`
+console.log(tsFiles);
+```
+
 ## API
 
 ### pWaitFor(condition, options?)
 
-Returns a `Promise` that resolves when `condition` returns `true`. Rejects if `condition` throws or returns a `Promise` that rejects.
+Returns a `Promise` that resolves when `condition` returns `true`. Rejects if `condition` throws or returns a `Promise` that rejects. An optional `resolve` callback is passed to `condition` that can be called to return a value from `pWaitFor` once `condition` returns true.
 
-#### condition
+#### condition(resolve)
 
 Type: `Function`
 
 Expected to return `Promise<boolean> | boolean`.
+
+##### resolve(value)
+
+Type: `Function`
+
+Can be called with a value to return once the condition returns true. The `resolve` function always returns true so you can write `return resolve(value)`.
 
 #### options
 

--- a/readme.md
+++ b/readme.md
@@ -65,7 +65,7 @@ Expected to return `Promise<boolean> | boolean`.
 
 Type: `Function`
 
-Can be called with a value to return once the condition returns true. The `resolve` function always returns true so you can write `return resolve(value)`.
+Can be called with a value to return from the `pWaitFor` function once the condition returns true. This function always returns true so you can write `return resolve(value)`.
 
 #### options
 

--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,7 @@ const jsFiles = await pWaitFor(async resolve => {
 console.log(jsFiles);
 ```
 
-Use with TypeScript:
+Usage with TypeScript:
 
 ```ts
 import {globby} from 'globby';

--- a/test.js
+++ b/test.js
@@ -70,3 +70,44 @@ test('does not perform a leading check', async t => {
 
 	t.true(end() > (ms - 20));
 });
+
+test('resolves with a value if the resolve callback is called', async t => {
+	const ms = 200;
+	const end = timeSpan();
+
+	const value = await pWaitFor(async resolve => {
+		await delay(ms);
+		return resolve('foo');
+	});
+
+	t.true(end() > (ms - 20));
+	t.is(value, 'foo');
+});
+
+test('only resolves the value when condition callback returns true', async t => {
+	let checksPerformed = 0;
+	const value = await pWaitFor(async resolve => {
+		if (checksPerformed === 1) {
+			return resolve('bar');
+		}
+
+		resolve('foo');
+		checksPerformed += 1;
+		return false;
+	});
+
+	t.is(value, 'bar');
+
+	checksPerformed = 0;
+	const value2 = await pWaitFor(async resolve => {
+		if (checksPerformed === 1) {
+			return resolve();
+		}
+
+		resolve('foo');
+		checksPerformed += 1;
+		return false;
+	});
+
+	t.is(value2, undefined);
+});

--- a/test.js
+++ b/test.js
@@ -101,7 +101,7 @@ test('only resolves the value when condition callback returns true', async t => 
 	checksPerformed = 0;
 	const value2 = await pWaitFor(async resolve => {
 		if (checksPerformed === 1) {
-			return resolve();
+			return true;
 		}
 
 		resolve('foo');


### PR DESCRIPTION
Inspired by https://github.com/sindresorhus/p-wait-for/issues/12#issuecomment-1016026512

The resolve function always returns true so you can write:
```ts
const value = await pWaitFor(resolve => {
  return resolve('foo');
});

// Equivalent to:
const value = await pWaitFor(resolve => {
  resolve('foo');
  return true;
});
```

Let me know what you think and if you'd like me to make any changes!