### PR TITLE
Add ability to return a value using an array

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -37,6 +37,9 @@ await pWaitFor(() => pathExists('unicorn.png'));
 console.log('Yay! The file now exists.');
 ```
 */
-export default function pWaitFor(condition: () => PromiseLike<boolean> | boolean, options?: Options): Promise<void>;
+export default function pWaitFor<T>(
+	condition: () => PromiseLike<boolean | [boolean, T]> | boolean | [boolean, T],
+	options?: Options
+): Promise<T>;
 
 export {TimeoutError} from 'p-timeout';

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ export default async function pWaitFor(condition, options = {}) {
 	const {
 		interval = 20,
 		timeout = Number.POSITIVE_INFINITY,
-		before = true
+		before = true,
 	} = options;
 
 	let retryTimeout;
@@ -14,12 +14,19 @@ export default async function pWaitFor(condition, options = {}) {
 			try {
 				const value = await condition();
 
-				if (typeof value !== 'boolean') {
-					throw new TypeError('Expected condition to return a boolean');
+				if (
+					typeof value !== 'boolean'
+					|| !(Array.isArray(value) && value.length === 2)
+				) {
+					throw new TypeError(
+						'Expected condition to return a boolean or an array of length 2',
+					);
 				}
 
-				if (value === true) {
+				if (typeof value === 'boolean' && value === true) {
 					resolve();
+				} else if (Array.isArray(value) && value[0] === true) {
+					resolve(value[1]);
 				} else {
 					retryTimeout = setTimeout(check, interval);
 				}

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ export default async function pWaitFor(condition, options = {}) {
 	const {
 		interval = 20,
 		timeout = Number.POSITIVE_INFINITY,
-		before = true,
+		before = true
 	} = options;
 
 	let retryTimeout;
@@ -15,11 +15,11 @@ export default async function pWaitFor(condition, options = {}) {
 				const value = await condition();
 
 				if (
-					typeof value !== 'boolean'
-					|| !(Array.isArray(value) && value.length === 2)
+					typeof value !== 'boolean' &&
+					!(Array.isArray(value) && value.length === 2)
 				) {
 					throw new TypeError(
-						'Expected condition to return a boolean or an array of length 2',
+						'Expected condition to return a boolean or an array of length 2'
 					);
 				}
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -6,3 +6,6 @@ expectType<Promise<void>>(pWaitFor(async () => false));
 expectType<Promise<void>>(pWaitFor(() => true, {interval: 1}));
 expectType<Promise<void>>(pWaitFor(() => true, {timeout: 1}));
 expectType<Promise<void>>(pWaitFor(() => true, {before: false}));
+
+expectType<Promise<number>>(pWaitFor(() => [true, 42]));
+expectType<Promise<number>>(pWaitFor(async () => [false, 42]));

--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,6 @@ const tsFiles = await pWaitFor(async () => {
 console.log(tsFiles);
 ```
 
->>>>>>> 2b859c3 (docs: update with optional array return value)
 ## API
 
 ### pWaitFor(condition, options?)

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,32 @@ await pWaitFor(() => pathExists('unicorn.png'));
 console.log('Yay! The file now exists.');
 ```
 
+Using an array as the return value:
+
+```js
+import {globby} from 'globby';
+
+const jsFiles = await pWaitFor(async resolve => {
+  const paths = await globby(['*.js']);
+  return [paths.length > 0, paths];
+});
+console.log(jsFiles);
+```
+
+Usage with TypeScript:
+
+```ts
+import {globby} from 'globby';
+
+const tsFiles = await pWaitFor(async resolve => {
+  const paths = await globby(['*.ts']);
+  return [paths.length > 0, paths];
+});
+// `tsFiles` is typed as a `string[]`
+console.log(tsFiles);
+```
+
+>>>>>>> 2b859c3 (docs: update with optional array return value)
 ## API
 
 ### pWaitFor(condition, options?)
@@ -30,7 +56,7 @@ Returns a `Promise` that resolves when `condition` returns `true`. Rejects if `c
 
 Type: `Function`
 
-Expected to return `Promise<boolean> | boolean`.
+Expected to return either `Promise<boolean> | boolean` or `Promise<[boolean, T]> | [boolean, T]` where T is type of a value returned by `pWaitFor`.
 
 #### options
 

--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,7 @@ Returns a `Promise` that resolves when `condition` returns `true`. Rejects if `c
 
 Type: `Function`
 
-Expected to return either `Promise<boolean> | boolean` or `Promise<[boolean, T]> | [boolean, T]` where T is type of a value returned by `pWaitFor`.
+Expected to return either `Promise<boolean> | boolean` or `Promise<[boolean, T]> | [boolean, T]` where T is the type of the value returned by `pWaitFor`.
 
 #### options
 

--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ Using an array as the return value:
 ```js
 import {globby} from 'globby';
 
-const jsFiles = await pWaitFor(async resolve => {
+const jsFiles = await pWaitFor(async () => {
   const paths = await globby(['*.js']);
   return [paths.length > 0, paths];
 });
@@ -37,7 +37,7 @@ Usage with TypeScript:
 ```ts
 import {globby} from 'globby';
 
-const tsFiles = await pWaitFor(async resolve => {
+const tsFiles = await pWaitFor(async () => {
   const paths = await globby(['*.ts']);
   return [paths.length > 0, paths];
 });

--- a/test.js
+++ b/test.js
@@ -19,7 +19,7 @@ test('rejects promise if condition rejects or throws', async t => {
 	await t.throwsAsync(
 		pWaitFor(() => {
 			throw new Error('foo');
-		}),
+		})
 	);
 });
 
@@ -36,9 +36,9 @@ test('waits no longer than `timeout` milliseconds before rejecting', async t => 
 			},
 			{
 				interval: 20,
-				timeout: maxWait,
-			},
-		),
+				timeout: maxWait
+			}
+		)
 	);
 
 	const timeTaken = end();
@@ -56,8 +56,8 @@ test('stops performing checks if a timeout occurs', async t => {
 		},
 		{
 			interval: 10,
-			timeout: 200,
-		},
+			timeout: 200
+		}
 	).catch(async _ => {
 		const checksAtTimeout = checksPerformed;
 		await delay(100);
@@ -71,7 +71,7 @@ test('does not perform a leading check', async t => {
 
 	await pWaitFor(async () => true, {
 		interval: ms,
-		before: false,
+		before: false
 	});
 
 	t.true(end() > ms - 20);
@@ -106,10 +106,10 @@ test('only resolves the value when the first value of the array is true', async 
 
 test('throws on invalid return value', async t => {
 	await t.throwsAsync(
-		pWaitFor(() => [false, false, false]),
+		pWaitFor(() => [false, false, false])
 	);
 
 	await t.throwsAsync(
-		pWaitFor(() => 42),
+		pWaitFor(() => 42)
 	);
 });

--- a/test.js
+++ b/test.js
@@ -12,7 +12,7 @@ test('waits for condition', async t => {
 		return true;
 	});
 
-	t.true(end() > ms - 20);
+	t.true(end() > (ms - 20));
 });
 
 test('rejects promise if condition rejects or throws', async t => {
@@ -80,7 +80,7 @@ test('resolves with a value if an array is returned', async t => {
 		return [true, 'foo'];
 	});
 
-	t.true(end() > ms - 20);
+	t.true(end() > (ms - 20));
 	t.is(value, 'foo');
 });
 

--- a/test.js
+++ b/test.js
@@ -99,7 +99,7 @@ test('only resolves the value when the first value of the array is true', async 
 });
 
 test('throws on invalid return value', async t => {
-	await t.throwsAsync( pWaitFor(() => [false, false, false])
+	await t.throwsAsync(pWaitFor(() => [false, false, false])
 	);
 
 	await t.throwsAsync(

--- a/test.js
+++ b/test.js
@@ -16,11 +16,9 @@ test('waits for condition', async t => {
 });
 
 test('rejects promise if condition rejects or throws', async t => {
-	await t.throwsAsync(
-		pWaitFor(() => {
-			throw new Error('foo');
-		})
-	);
+	await t.throwsAsync(pWaitFor(() => {
+		throw new Error('foo');
+	}));
 });
 
 test('waits no longer than `timeout` milliseconds before rejecting', async t => {
@@ -28,22 +26,17 @@ test('waits no longer than `timeout` milliseconds before rejecting', async t => 
 	const ms = 200;
 	const maxWait = 100;
 
-	await t.throwsAsync(
-		pWaitFor(
-			async () => {
-				await delay(ms);
-				return true;
-			},
-			{
-				interval: 20,
-				timeout: maxWait
-			}
-		)
-	);
+	await t.throwsAsync(pWaitFor(async () => {
+		await delay(ms);
+		return true;
+	}, {
+		interval: 20,
+		timeout: maxWait
+	}));
 
 	const timeTaken = end();
 	t.true(timeTaken < ms);
-	t.true(timeTaken > maxWait - 20);
+	t.true(timeTaken > (maxWait - 20));
 });
 
 test('stops performing checks if a timeout occurs', async t => {
@@ -58,11 +51,12 @@ test('stops performing checks if a timeout occurs', async t => {
 			interval: 10,
 			timeout: 200
 		}
-	).catch(async _ => {
-		const checksAtTimeout = checksPerformed;
-		await delay(100);
-		t.is(checksPerformed, checksAtTimeout);
-	});
+	)
+		.catch(async _ => {
+			const checksAtTimeout = checksPerformed;
+			await delay(100);
+			t.is(checksPerformed, checksAtTimeout);
+		});
 });
 
 test('does not perform a leading check', async t => {
@@ -74,7 +68,7 @@ test('does not perform a leading check', async t => {
 		before: false
 	});
 
-	t.true(end() > ms - 20);
+	t.true(end() > (ms - 20));
 });
 
 test('resolves with a value if an array is returned', async t => {
@@ -105,8 +99,7 @@ test('only resolves the value when the first value of the array is true', async 
 });
 
 test('throws on invalid return value', async t => {
-	await t.throwsAsync(
-		pWaitFor(() => [false, false, false])
+	await t.throwsAsync( pWaitFor(() => [false, false, false])
 	);
 
 	await t.throwsAsync(


### PR DESCRIPTION
This is an alternative idea to #22, which had a few issues such as proper type inference for TypeScript and the extra mental burden of having to remember to return the result of `resolve`.

It's inspired by the idea of an object return value (https://github.com/sindresorhus/p-wait-for/issues/12#issuecomment-753219059), but instead of an object (which is a bit verbose), it uses a return value of an array of length 2 where the first argument is either `true` or `false` and the second argument is the value to return from `pWaitFor` if the first argument is `true`. Thus, the API would look something as follows:

```typescript
import {globby} from 'globby';

const jsFiles = await pWaitFor(async () => {
  const paths = await globby(['*.js']);
  return [paths.length > 0, paths];
});
console.log(jsFiles);
```

This has the added benefit of working with TypeScript type inference:
```typescript
expectType<Promise<number>>(pWaitFor(() => [true, 42]));
```