### PR TITLE
Expose all timeout options (custom `message`, `customTimers`)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,33 +1,6 @@
-import {Options as pTimeoutOptions} from 'p-timeout';
+import {Options as TimeoutOptions} from 'p-timeout';
 
-export interface TimeoutOptions {
-	/**
-	Milliseconds before timing out.
-
-	Error will be thrown if `pWaitFor` promise hasn't resolved/rejected until this `milliseconds`.
-
-	Passing `Infinity` will cause it to never time out.
-
-	@default Infinity
-	*/
-	milliseconds?: number;
-
-	/**
-	Specify a custom error message or error.
-
-	If you do a custom error, it's recommended to sub-class `TimeoutError`.
-	*/
-	message?: string | Error;
-
-	/**
-	Custom implementations for the `setTimeout` and `clearTimeout` functions.
-
-	Useful for testing purposes, in particular to work around [`sinon.useFakeTimers()`](https://sinonjs.org/releases/latest/fake-timers/).
-	*/
-	customTimers?: pTimeoutOptions['customTimers'];
-}
-
-export interface Options {
+export interface Options<ResolveValueType> {
 	/**
 	Number of milliseconds to wait after `condition` resolves to `false` before calling it again.
 
@@ -47,12 +20,18 @@ export interface Options {
 	import pWaitFor from 'p-wait-for';
 	import {pathExists} from 'path-exists';
 
+	const originalSetTimeout = setTimeout;
+	const originalClearTimeout = clearTimeout;
+
+	sinon.useFakeTimers();
+
 	await pWaitFor(() => pathExists('unicorn.png'), {
 		timeout: {
 			milliseconds: 100,
 			message: new MyError('Time’s up!'),
 			customTimers: {
-				setTimeout: requestAnimationFrame
+				setTimeout: originalSetTimeout,
+				clearTimeout: originalClearTimeout
 			}
 		}
 	});
@@ -60,7 +39,7 @@ export interface Options {
 	console.log('Yay! The file now exists.');
 	```
 	*/
-	readonly timeout?: number | TimeoutOptions;
+	readonly timeout?: number | TimeoutOptions<ResolveValueType>;
 
 	/**
 	Whether to run the check immediately rather than starting by waiting `interval` milliseconds.
@@ -94,7 +73,7 @@ declare const pWaitFor: {
 	console.log('Yay! The file now exists.');
 	```
 	*/
-	<ResolveValueType>(condition: () => PromiseLike<boolean> | boolean | ResolveValue<ResolveValueType> | PromiseLike<ResolveValue<ResolveValueType>>, options?: Options): Promise<ResolveValueType>;
+	<ResolveValueType>(condition: () => PromiseLike<boolean> | boolean | ResolveValue<ResolveValueType> | PromiseLike<ResolveValue<ResolveValueType>>, options?: Options<ResolveValueType>): Promise<ResolveValueType>;
 
 	/**
 	Resolve the main promise with a custom value.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,31 @@
+export interface TimeoutOptions {
+	/**
+	Milliseconds before timing out.
+
+	Passing `Infinity` will cause it to never time out.
+
+	@default Infinity
+	*/
+	milliseconds?: number;
+
+	/**
+	Specify a custom error message or error.
+
+	If you do a custom error, it's recommended to sub-class `pTimeout.TimeoutError`.
+	*/
+	message?: string | Error;
+
+	/**
+	Custom implementations for the `setTimeout` and `clearTimeout` functions.
+
+	Useful for testing purposes, in particular to work around [`sinon.useFakeTimers()`](https://sinonjs.org/releases/latest/fake-timers/).
+	*/
+	customTimers?: {
+		setTimeout: typeof global.setTimeout;
+		clearTimeout: typeof global.clearTimeout;
+	};
+}
+
 export interface Options {
 	/**
 	Number of milliseconds to wait after `condition` resolves to `false` before calling it again.
@@ -11,7 +39,7 @@ export interface Options {
 
 	@default Infinity
 	*/
-	readonly timeout?: number;
+	readonly timeout?: number | TimeoutOptions;
 
 	/**
 	Whether to run the check immediately rather than starting by waiting `interval` milliseconds.

--- a/index.d.ts
+++ b/index.d.ts
@@ -43,7 +43,7 @@ export interface Options {
 	@default Infinity
 
 	@example
-	```js
+	```
 	import pWaitFor from 'p-wait-for';
 	import {pathExists} from 'path-exists';
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,10 @@
+import {Options as pTimeoutOptions} from 'p-timeout';
+
 export interface TimeoutOptions {
 	/**
 	Milliseconds before timing out.
+
+	Error will be thrown if `pWaitFor` promise hasn't resolved/rejected until this `milliseconds`.
 
 	Passing `Infinity` will cause it to never time out.
 
@@ -20,10 +24,7 @@ export interface TimeoutOptions {
 
 	Useful for testing purposes, in particular to work around [`sinon.useFakeTimers()`](https://sinonjs.org/releases/latest/fake-timers/).
 	*/
-	customTimers?: {
-		setTimeout: typeof globalThis.setTimeout;
-		clearTimeout: typeof globalThis.clearTimeout;
-	};
+	customTimers?: pTimeoutOptions['customTimers'];
 }
 
 export interface Options {

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,7 +11,7 @@ export interface TimeoutOptions {
 	/**
 	Specify a custom error message or error.
 
-	If you do a custom error, it's recommended to sub-class `pTimeout.TimeoutError`.
+	If you do a custom error, it's recommended to sub-class `TimeoutError`.
 	*/
 	message?: string | Error;
 
@@ -21,8 +21,8 @@ export interface TimeoutOptions {
 	Useful for testing purposes, in particular to work around [`sinon.useFakeTimers()`](https://sinonjs.org/releases/latest/fake-timers/).
 	*/
 	customTimers?: {
-		setTimeout: typeof global.setTimeout;
-		clearTimeout: typeof global.clearTimeout;
+		setTimeout: typeof globalThis.setTimeout;
+		clearTimeout: typeof globalThis.clearTimeout;
 	};
 }
 
@@ -37,7 +37,27 @@ export interface Options {
 	/**
 	Number of milliseconds to wait before automatically rejecting with a `TimeoutError`.
 
+	You can customize the timeout `Error` by specifying `TimeoutOptions`.
+
 	@default Infinity
+
+	@example
+	```js
+	import pWaitFor from 'p-wait-for';
+	import {pathExists} from 'path-exists';
+
+	await pWaitFor(() => pathExists('unicorn.png'), {
+		timeout: {
+			milliseconds: 100,
+			message: new MyError('Time’s up!'),
+			customTimers: {
+				setTimeout: requestAnimationFrame
+			}
+		}
+	});
+
+	console.log('Yay! The file now exists.');
+	```
 	*/
 	readonly timeout?: number | TimeoutOptions;
 

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ export default async function pWaitFor(condition, options = {}) {
 		}
 	});
 
-	if (timeout === Infinity) {
+	if (timeout === Number.POSITIVE_INFINITY) {
 		return promise;
 	}
 

--- a/index.js
+++ b/index.js
@@ -53,7 +53,11 @@ export default async function pWaitFor(condition, options = {}) {
 	const customTimersOptions = customTimers ? {customTimers} : undefined;
 
 	try {
-		return await pTimeout(promise, timeoutMs, timeoutMessage, customTimersOptions);
+		return await pTimeout(promise, {
+			milliseconds: timeoutMs,
+			message: timeoutMessage,
+			customTimers: customTimersOptions
+		});
 	} catch (error) {
 		if (retryTimeout) {
 			clearTimeout(retryTimeout);

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ export default async function pWaitFor(condition, options = {}) {
 		}
 	});
 
-	if (timeout === Number.POSITIVE_INFINITY) {
+	if (timeout === Infinity) {
 		return promise;
 	}
 

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ import pTimeout from 'p-timeout';
 const resolveValue = Symbol('resolveValue');
 
 export default async function pWaitFor(condition, options = {}) {
-	let timeout = options.timeout ? options.timeout : Number.POSITIVE_INFINITY;
+	const timeout = options.timeout ? options.timeout : Number.POSITIVE_INFINITY;
 
 	const {
 		interval = 20,
@@ -38,21 +38,22 @@ export default async function pWaitFor(condition, options = {}) {
 		}
 	});
 
-	if (typeof timeout === 'number' && timeout === Number.POSITIVE_INFINITY) {
+	if (timeout === Number.POSITIVE_INFINITY) {
 		return promise;
 	}
 
-	let customTimerOptions;
-	let timeoutMessage;
+	const milliseconds = timeout;
 
-	if (typeof timeout !== 'number') {
-		customTimerOptions = timeout.customTimers;
-		timeoutMessage = timeout.message;
-		timeout = timeout.milliseconds;
-	}
+	const {
+		message: timeoutMessage,
+		milliseconds: timeoutMs,
+		customTimers
+	} = typeof timeout === 'number' ? {milliseconds} : timeout;
+
+	const customTimersOptions = customTimers ? {customTimers} : undefined;
 
 	try {
-		return await pTimeout(promise, timeout, timeoutMessage, customTimerOptions);
+		return await pTimeout(promise, timeoutMs, timeoutMessage, customTimersOptions);
 	} catch (error) {
 		if (retryTimeout) {
 			clearTimeout(retryTimeout);

--- a/index.js
+++ b/index.js
@@ -3,10 +3,9 @@ import pTimeout from 'p-timeout';
 const resolveValue = Symbol('resolveValue');
 
 export default async function pWaitFor(condition, options = {}) {
-	const timeout = options.timeout ? options.timeout : Number.POSITIVE_INFINITY;
-
 	const {
 		interval = 20,
+		timeout = Number.POSITIVE_INFINITY,
 		before = true
 	} = options;
 
@@ -42,28 +41,10 @@ export default async function pWaitFor(condition, options = {}) {
 		return promise;
 	}
 
-	const milliseconds = timeout;
-
-	const {
-		message: timeoutMessage,
-		milliseconds: timeoutMs,
-		customTimers
-	} = typeof timeout === 'number' ? {milliseconds} : timeout;
-
-	const customTimersOptions = customTimers ? {customTimers} : undefined;
-
 	try {
-		return await pTimeout(promise, {
-			milliseconds: timeoutMs,
-			message: timeoutMessage,
-			customTimers: customTimersOptions
-		});
-	} catch (error) {
-		if (retryTimeout) {
-			clearTimeout(retryTimeout);
-		}
-
-		throw error;
+		return await pTimeout(promise, typeof timeout === 'number' ? {milliseconds: timeout} : timeout);
+	} finally {
+		clearTimeout(retryTimeout);
 	}
 }
 

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ import pTimeout from 'p-timeout';
 const resolveValue = Symbol('resolveValue');
 
 export default async function pWaitFor(condition, options = {}) {
-	let timeout = options.timeout ?? Number.POSITIVE_INFINITY;
+	let timeout = options.timeout ? options.timeout : Number.POSITIVE_INFINITY;
 
 	const {
 		interval = 20,

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"bluebird"
 	],
 	"dependencies": {
-		"p-timeout": "^5.0.0"
+		"p-timeout": "^6.0.0"
 	},
 	"devDependencies": {
 		"ava": "^3.15.0",

--- a/readme.md
+++ b/readme.md
@@ -45,10 +45,54 @@ Number of milliseconds to wait after `condition` resolves to `false` before call
 
 ##### timeout
 
-Type: `number`\
+Type: `number | TimeoutOption`\
 Default: `Infinity`
 
 Number of milliseconds to wait before automatically rejecting with a `TimeoutError`.
+
+You can customize the `TimeoutError` by specifying `TimeoutOption` instead of `number`.
+
+```js
+import pWaitFor from 'p-wait-for';
+import {pathExists} from 'path-exists';
+
+await pWaitFor(() => pathExists('unicorn.png'), {
+	timeout: {
+		milliseconds: 100,
+		message: MyError('Time’s up!'),
+		customTimers: {
+			setTimeout: requestAnimationFrame
+		}
+	}
+});
+console.log('Yay! The file now exists.');
+```
+
+###### milliseconds
+
+Type: `number`\
+Default: `Infinity`
+
+Milliseconds before timing out.
+
+Passing `Infinity` will cause it to never time out.
+
+###### message
+
+Type: `string | Error`
+Default: `'Promise timed out after 50 milliseconds'`
+
+Specify a custom error message or error.
+
+If you do a custom error, it's recommended to sub-class `pTimeout.TimeoutError`.
+
+###### customTimers
+
+Type: `object` with function properties `setTimeout` and `clearTimeout`
+
+Custom implementations for the `setTimeout` and `clearTimeout` functions.
+
+Useful for testing purposes, in particular to work around [`sinon.useFakeTimers()`](https://sinonjs.org/releases/latest/fake-timers/).
 
 ##### before
 

--- a/readme.md
+++ b/readme.md
@@ -45,12 +45,12 @@ Number of milliseconds to wait after `condition` resolves to `false` before call
 
 ##### timeout
 
-Type: `number | TimeoutOption`\
+Type: `number | TimeoutOptions`\
 Default: `Infinity`
 
 Number of milliseconds to wait before automatically rejecting with a `TimeoutError`.
 
-You can customize the `TimeoutError` by specifying `TimeoutOption` instead of `number`.
+You can customize the `TimeoutError` by specifying `TimeoutOptions` instead of `number`.
 
 ```js
 import pWaitFor from 'p-wait-for';

--- a/readme.md
+++ b/readme.md
@@ -50,7 +50,7 @@ Default: `Infinity`
 
 Number of milliseconds to wait before automatically rejecting with a `TimeoutError`.
 
-You can customize the `TimeoutError` by specifying `TimeoutOptions` instead of `number`.
+You can customize the timeout `Error` by specifying `TimeoutOptions`.
 
 ```js
 import pWaitFor from 'p-wait-for';
@@ -59,12 +59,13 @@ import {pathExists} from 'path-exists';
 await pWaitFor(() => pathExists('unicorn.png'), {
 	timeout: {
 		milliseconds: 100,
-		message: MyError('Time’s up!'),
+		message: new MyError('Time’s up!'),
 		customTimers: {
 			setTimeout: requestAnimationFrame
 		}
 	}
 });
+
 console.log('Yay! The file now exists.');
 ```
 
@@ -84,7 +85,7 @@ Default: `'Promise timed out after 50 milliseconds'`
 
 Specify a custom error message or error.
 
-If you do a custom error, it's recommended to sub-class `pTimeout.TimeoutError`.
+If you do a custom error, it's recommended to sub-class `TimeoutError`.
 
 ###### customTimers
 

--- a/readme.md
+++ b/readme.md
@@ -56,12 +56,18 @@ You can customize the timeout `Error` by specifying `TimeoutOptions`.
 import pWaitFor from 'p-wait-for';
 import {pathExists} from 'path-exists';
 
+const originalSetTimeout = setTimeout;
+const originalClearTimeout = clearTimeout;
+
+sinon.useFakeTimers();
+
 await pWaitFor(() => pathExists('unicorn.png'), {
 	timeout: {
 		milliseconds: 100,
 		message: new MyError('Time’s up!'),
 		customTimers: {
-			setTimeout: requestAnimationFrame
+			setTimeout: originalSetTimeout,
+			clearTimeout: originalClearTimeout
 		}
 	}
 });
@@ -94,6 +100,28 @@ Type: `object` with function properties `setTimeout` and `clearTimeout`
 Custom implementations for the `setTimeout` and `clearTimeout` functions.
 
 Useful for testing purposes, in particular to work around [`sinon.useFakeTimers()`](https://sinonjs.org/releases/latest/fake-timers/).
+
+###### fallback
+
+Type: `Function`
+
+Do something other than rejecting with an error on timeout.
+
+Example:
+
+```js
+import pWaitFor from 'p-wait-for';
+import {pathExists} from 'path-exists';
+
+await pWaitFor(() => pathExists('unicorn.png'), {
+	timeout: {
+		milliseconds: 50,
+		fallback: () => {
+			console.log('Time’s up! executed the fallback function!');
+		},
+	}
+});
+```
 
 ##### before
 

--- a/test.js
+++ b/test.js
@@ -75,7 +75,7 @@ test('resolveWith()', async t => {
 	t.true(await pWaitFor(() => pWaitFor.resolveWith(true)));
 });
 
-test('Customize timeout error', async t => {
+test('timeout option - object', async t => {
 	class CustomizedTimeoutError extends Error {
 		constructor() {
 			super();

--- a/test.js
+++ b/test.js
@@ -74,3 +74,27 @@ test('does not perform a leading check', async t => {
 test('resolveWith()', async t => {
 	t.true(await pWaitFor(() => pWaitFor.resolveWith(true)));
 });
+
+test('Customize timeout error', async t => {
+	class CustomizedTimeoutError extends Error {
+		constructor() {
+			super();
+			this.name = 'MyError';
+			this.message = 'Time’s up!';
+		}
+	}
+
+	await t.throwsAsync(pWaitFor(async () => {
+		await delay(1000);
+		return true;
+	}, {
+		timeout: {
+			milliseconds: 100,
+			message: new CustomizedTimeoutError()
+		}
+	}), {
+		name: 'MyError',
+		message: 'Time’s up!',
+		instanceOf: CustomizedTimeoutError
+	});
+});


### PR DESCRIPTION
Fixes #20.

Relevant documentation are copy-pasted from [p-timeout](https://github.com/sindresorhus/p-timeout)'s documentation.
