### PR TITLE
Fix types to support returning boolean and `resolveWith()` on the same callback

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -73,7 +73,7 @@ declare const pWaitFor: {
 	console.log('Yay! The file now exists.');
 	```
 	*/
-	<ResolveValueType>(condition: () => PromiseLike<boolean> | boolean | ResolveValue<ResolveValueType> | PromiseLike<ResolveValue<ResolveValueType>>, options?: Options<ResolveValueType>): Promise<ResolveValueType>;
+	<ResolveValueType>(condition: () => PromiseLike<boolean | ResolveValue<ResolveValueType>> | PromiseLike<boolean> | boolean | ResolveValue<ResolveValueType> | PromiseLike<ResolveValue<ResolveValueType>>, options?: Options<ResolveValueType>): Promise<ResolveValueType>;
 
 	/**
 	Resolve the main promise with a custom value.

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -8,3 +8,4 @@ expectType<Promise<void>>(pWaitFor(() => true, {timeout: 1}));
 expectType<Promise<void>>(pWaitFor(() => true, {before: false}));
 expectType<Promise<number>>(pWaitFor(() => pWaitFor.resolveWith(1)));
 expectType<Promise<number>>(pWaitFor(() => pWaitFor.resolveWith(1)));
+expectType<Promise<number>>(pWaitFor(async () => true as boolean && pWaitFor.resolveWith(1)));


### PR DESCRIPTION
### Summary

Hey :)

This PR adjusts the types to support an async callback that can return either a boolean, or a value returned with `resolveWith()`.

The following currently shows a type error, which passes with the PR changes:

```typescript
import pWaitFor from 'p-wait-for';
import pathExists from 'path-exists';

const path = await pWaitFor(async () => {
	const path = getPath();
	return await pathExists(path) && pWaitFor.resolveWith(path);
});

console.log(path);
```

I created a small repro on the [TypeScript Playground](https://www.typescriptlang.org/play?#code/C4TwDgpgBAShDOB7ANgNwgdQJbABYB4AVAPigF4oBvKAawhAC4pCoBfAbgChPRIoA1AIbIArhCKkynKFAA+UAAoAnRAFss8CABksdfHCRpMOAiWLS5iles069AI0QoIggHbmA9B5mXlajdq64gYo6Nh4EpaOzm7EXJyC8CCuAMZQAGYiqcBYiK5QAO6COBIAFCn2TKUAlOSkQqLiJLWUrNxFOKWJyWmZ2bn5NVQWWOlQpQVYrgAmiAUtFjJKEMAiSvnpwppcMm0Wy6vrVLT0TABEqMJiZ2xcrNVcQA) and also created a test for this (that fails on the `main` branch).

Edit: I can see Node v12 tests fail since the v5 release [which requires Node v14 or above](https://github.com/sindresorhus/p-wait-for/releases/tag/v5.0.0) and aren't related to this change. I created a PR to address this: https://github.com/sindresorhus/p-wait-for/pull/30.
