### PR TITLE
Remove Node v12 from CI matrix to fix failing CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,6 @@ jobs:
           - 18
           - 16
           - 14
-          - 12
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3


### PR DESCRIPTION
### Summary

Node v12 tests fail since the v5 release [which requires Node v14 or above](https://github.com/sindresorhus/p-wait-for/releases/tag/v5.0.0).

This PR fixes the currently failing CI by removing Node v12 from the CI matrix.
