### PR TITLE
Add support for aborting with `AbortSignal`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -49,6 +49,32 @@ export type Options<ResolveValueType> = {
 	@default true
 	*/
 	readonly before?: boolean;
+
+	/**
+	You can abort retrying using [`AbortController`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController).
+
+	_Requires Node.js 16 or later._
+
+	@example
+	```
+	import pWaitFor from 'p-wait-for';
+	import delay from 'delay';
+
+	const delayedPromise = delay(3000);
+
+	const abortController = new AbortController();
+
+	setTimeout(() => {
+		abortController.abort();
+	}, 100);
+
+	await pWaitFor(delayedPromise, {
+		timeout: 2000,
+		signal: abortController.signal
+	});
+	```
+	*/
+	readonly signal?: globalThis.AbortSignal;
 };
 
 // https://github.com/sindresorhus/type-fest/blob/043b732bf02c2b700245aa6501116a6646d50732/source/opaque.d.ts

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ export default async function pWaitFor(condition, options = {}) {
 		interval = 20,
 		timeout = Number.POSITIVE_INFINITY,
 		before = true,
+		signal,
 	} = options;
 
 	let retryTimeout;
@@ -43,7 +44,7 @@ export default async function pWaitFor(condition, options = {}) {
 	}
 
 	try {
-		return await pTimeout(promise, typeof timeout === 'number' ? {milliseconds: timeout} : timeout);
+		return await pTimeout(promise, typeof timeout === 'number' ? {milliseconds: timeout, signal} : timeout);
 	} finally {
 		abort = true;
 		clearTimeout(retryTimeout);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,10 +1,13 @@
 import {expectType} from 'tsd';
 import pWaitFor from './index.js';
 
+const controller = new AbortController();
+
 expectType<Promise<void>>(pWaitFor(() => false));
 expectType<Promise<void>>(pWaitFor(async () => false));
 expectType<Promise<void>>(pWaitFor(() => true, {interval: 1}));
 expectType<Promise<void>>(pWaitFor(() => true, {timeout: 1}));
+expectType<Promise<void>>(pWaitFor(() => true, {signal: controller.signal}));
 expectType<Promise<void>>(pWaitFor(() => true, {before: false}));
 expectType<Promise<number>>(pWaitFor(() => pWaitFor.resolveWith(1)));
 expectType<Promise<number>>(pWaitFor(() => pWaitFor.resolveWith(1)));

--- a/readme.md
+++ b/readme.md
@@ -75,6 +75,33 @@ await pWaitFor(() => pathExists('unicorn.png'), {
 console.log('Yay! The file now exists.');
 ```
 
+##### signal
+
+Type: `AbortSignal?`\
+Default: `Infinity`
+
+You can abort retrying using [`AbortController`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController).
+
+_Requires Node.js 16 or later._
+
+```js
+import pWaitFor from 'p-wait-for';
+import delay from 'delay';
+
+const delayedPromise = delay(3000);
+
+const abortController = new AbortController();
+
+setTimeout(() => {
+	abortController.abort();
+}, 100);
+
+await pWaitFor(delayedPromise, {
+	timeout: 2000,
+	signal: abortController.signal
+});
+```
+
 ###### milliseconds
 
 Type: `number`\

--- a/test.js
+++ b/test.js
@@ -122,3 +122,42 @@ test('timeout option - object', async t => {
 		instanceOf: CustomizedTimeoutError,
 	});
 });
+
+/**
+TODO: Remove if statement when targeting Node.js 16.
+*/
+if (globalThis.AbortController !== undefined) {
+	test('rejects when calling `AbortController#abort()`', async t => {
+		const abortController = new AbortController();
+
+		const promise = pWaitFor(async () => {
+			await delay(3000);
+			return true;
+		}, {
+			timeout: 2000,
+			signal: abortController.signal,
+		});
+
+		abortController.abort();
+
+		await t.throwsAsync(promise, {
+			name: 'AbortError',
+		});
+	});
+
+	test('already aborted signal', async t => {
+		const abortController = new AbortController();
+
+		abortController.abort();
+
+		await t.throwsAsync(pWaitFor(async () => {
+			await delay(3000);
+			return true;
+		}, {
+			timeout: 2000,
+			signal: abortController.signal,
+		}), {
+			name: 'AbortError',
+		});
+	});
+}


### PR DESCRIPTION
### Summary

This PR add support for aborting re-tries with an `AbortSignal`. This is similar to how it's being handled on other packages like https://github.com/sindresorhus/p-retry and https://github.com/sindresorhus/p-timeout.

This is necessary because currently there's no way to stop the polling other than returning `true` (which may need different handling than when the `condition` resolves with `true`).

This PR is currently failing on CI because of an unrelated issue, [I described it here](https://github.com/sindresorhus/p-wait-for/pull/32) along with a potential way of fixing it.
